### PR TITLE
Enhance usability of ModelZoo-YOLOv8

### DIFF
--- a/auto_process.py
+++ b/auto_process.py
@@ -1,6 +1,7 @@
 import argparse
 
 from loguru import logger
+from netspresso.compressor import ModelCompressor, Task, Framework
 
 from ultralytics import YOLO
 
@@ -11,8 +12,17 @@ def parse_args():
     """
         Common arguments
     """
+    parser.add_argument('-n', '--name', type=str, default='yolov8n', help='model name')
     parser.add_argument('-w', '--weights', type=str, default='./yolov8n.pt', help='weights path')
 
+    """
+        Compression arguments
+    """
+    parser.add_argument("--compression_method", type=str, choices=["PR_L2", "PR_GM", "PR_NN", "PR_ID", "FD_TK", "FD_CP", "FD_SVD"], default="PR_L2")
+    parser.add_argument("--recommendation_method", type=str, choices=["slamp", "vbmf"], default="slamp")
+    parser.add_argument("--compression_ratio", type=int, default=0.5)
+    parser.add_argument("-m", "--np_email", help="NetsPresso login e-mail", type=str)
+    parser.add_argument("-p", "--np_password", help="NetsPresso login password", type=str)
 
     return parser.parse_args()
 
@@ -21,6 +31,7 @@ if __name__ == '__main__':
     args = parse_args()
 
     model = YOLO(args.weights)
+    model_args = model.model.args
 
     """ 
         Convert YOLOv8 model to fx 
@@ -32,3 +43,38 @@ if __name__ == '__main__':
 
     logger.info("yolov8 to fx graph end.")
     
+    """
+        Model compression - recommendation compression 
+    """
+    logger.info("Compression step start.")
+    
+    compressor = ModelCompressor(email=args.np_email, password=args.np_password)
+
+    UPLOAD_MODEL_NAME = args.name
+    TASK = Task.OBJECT_DETECTION
+    FRAMEWORK = Framework.PYTORCH
+    UPLOAD_MODEL_PATH = 'model_fx.pt'
+    INPUT_SHAPES = [{"batch": 1, "channel": 3, "dimension": (model_args['imgsz'], model_args['imgsz'])}]
+    model = compressor.upload_model(
+        model_name=UPLOAD_MODEL_NAME,
+        task=TASK,
+        framework=FRAMEWORK,
+        file_path=UPLOAD_MODEL_PATH,
+        input_shapes=INPUT_SHAPES,
+    )
+
+    COMPRESSION_METHOD = args.compression_method
+    RECOMMENDATION_METHOD = args.recommendation_method
+    RECOMMENDATION_RATIO = args.compression_ratio
+    COMPRESSED_MODEL_NAME = f'{UPLOAD_MODEL_NAME}_{COMPRESSION_METHOD}_{RECOMMENDATION_RATIO}'
+    OUTPUT_PATH = COMPRESSED_MODEL_NAME + '.pt'
+    compressed_model = compressor.recommendation_compression(
+        model_id=model.model_id,
+        model_name=COMPRESSED_MODEL_NAME,
+        compression_method=COMPRESSION_METHOD,
+        recommendation_method=RECOMMENDATION_METHOD,
+        recommendation_ratio=RECOMMENDATION_RATIO,
+        output_path=OUTPUT_PATH,
+    )
+
+    logger.info("Compression step end.")

--- a/auto_process.py
+++ b/auto_process.py
@@ -33,6 +33,7 @@ def parse_args():
     """
     parser.add_argument('--data', type=str, default='./ultralytics/datasets/coco128.yaml', help='model.yaml path')
     parser.add_argument('--epochs', type=int, default=100, help='retrain epoch')
+    parser.add_argument('--device', default='0', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
 
     return parser.parse_args()
 
@@ -95,6 +96,7 @@ if __name__ == '__main__':
     logger.info("Fine-tuning step start.")
 
     if args.config == '':
+        model.ckpt['train_args']['device'] = ''
         with open('tmp_cfg.yaml', 'w') as f:
             yaml.dump(model.ckpt['train_args'], f)
     else:
@@ -104,7 +106,7 @@ if __name__ == '__main__':
     model = YOLO_netspresso(OUTPUT_PATH, './netspresso_head_meta.json', model_args['task'] + '_retraining', 'tmp_cfg.yaml')
     os.remove('tmp_cfg.yaml')
 
-    model.train(data=args.data, epochs=args.epochs, lr0=lr)
+    model.train(data=args.data, epochs=args.epochs, lr0=lr, device=args.device)
     metrics = model.val(data=args.data)
 
     logger.info("Fine-tuning step end.")

--- a/auto_process.py
+++ b/auto_process.py
@@ -1,0 +1,34 @@
+import argparse
+
+from loguru import logger
+
+from ultralytics import YOLO
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+
+    """
+        Common arguments
+    """
+    parser.add_argument('-w', '--weights', type=str, default='./yolov8n.pt', help='weights path')
+
+
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    args = parse_args()
+
+    model = YOLO(args.weights)
+
+    """ 
+        Convert YOLOv8 model to fx 
+    """
+    logger.info("yolov8 to fx graph start.")
+
+    # save model.fx and netpresso_head_meta.json
+    model.export_netspresso()
+
+    logger.info("yolov8 to fx graph end.")
+    

--- a/auto_process.py
+++ b/auto_process.py
@@ -17,6 +17,7 @@ def parse_args():
     """
     parser.add_argument('-n', '--name', type=str, default='yolov8n', help='model name')
     parser.add_argument('-w', '--weights', type=str, default='./yolov8n.pt', help='weights path')
+    parser.add_argument('--config', type=str, default='', help='custom config path')
 
     """
         Compression arguments
@@ -93,8 +94,11 @@ if __name__ == '__main__':
     """
     logger.info("Fine-tuning step start.")
 
-    with open('tmp_cfg.yaml', 'w') as f:
-        yaml.dump(model.ckpt['train_args'], f)
+    if args.config == '':
+        with open('tmp_cfg.yaml', 'w') as f:
+            yaml.dump(model.ckpt['train_args'], f)
+    else:
+        shutil.copy(args.config, 'tmp_cfg.yaml')
 
     lr = model.ckpt['train_args']['lr0'] * 0.1
     model = YOLO_netspresso(OUTPUT_PATH, './netspresso_head_meta.json', model_args['task'] + '_retraining', 'tmp_cfg.yaml')

--- a/auto_process.py
+++ b/auto_process.py
@@ -24,7 +24,7 @@ def parse_args():
     """
     parser.add_argument("--compression_method", type=str, choices=["PR_L2", "PR_GM", "PR_NN", "PR_ID", "FD_TK", "FD_CP", "FD_SVD"], default="PR_L2")
     parser.add_argument("--recommendation_method", type=str, choices=["slamp", "vbmf"], default="slamp")
-    parser.add_argument("--compression_ratio", type=int, default=0.5)
+    parser.add_argument("--compression_ratio", type=int, default=0.3)
     parser.add_argument("-m", "--np_email", help="NetsPresso login e-mail", type=str)
     parser.add_argument("-p", "--np_password", help="NetsPresso login password", type=str)
 


### PR DESCRIPTION
Slack link: https://nota-workspace.slack.com/archives/C040F65LSAJ/p1692766946904609
Notion link: https://www.notion.so/notaai/YOLOv8-f8802393de284f5794ed949bc89dbca5?pvs=4

목적
---
ModelZoo에서 세분화된 기능을 하나로 합쳐서 하나의 파일만 실행하면 경량화 → 재학습 → onnx export까지 되어 LaunchX 사용 가능하게 한다.

변경 사항
---
- auto_process.py 파일을 생성했습니다. fx 변환, 경량화, 재학습, onnx 변환 이라는 단계를 거치며, 이를 위해 다음과 같은 argument를 받습니다.
  - 모델 이름 (ex. yolov8)
  - 모델 weight path (ex. yolov8.pt)
  - NetsPresso 계정 이메일
  - NetsPresso 계정 비밀번호
- 최대한 기존 코드의 수정을 막기 위해, 필요한 코드들을 가져와 순서대로 작동하도록 구성했습니다.
  - 대부분의 기능이 모델 객체 내부에 메소드로 존재하고 있기 때문에, 이들을 적절하게 호출하는 방법으로 구성했습니다.
- 코드 실행으로 발생하는 fx와 onnx 파일은 root 디렉토리에 생성됩니다.
- 테스트
  - detection ,segmentation, classification, pose estimation 에 대해 모두 테스트를 진행했습니다.
  - `python auto_process.py -n {name} -w {weights} --compression_method {compression} --recommendation_method {recommendation} --np_email {email} --np_password {password} --data {data_config}`
  - `name`: 
    - yolov8n, yolov8s, yolov8x
    - yolov8n-seg, yolov8s-seg, yolov8x-seg
    - yolov8n-cls, yolov8s-cls, yolov8x-cls
    - yolov8n-pose, yolov8s-pose, yolov8x-pose-p6
  - `compression`: PR_L2, FD_TK
  - `recommend`: slamp, vbmf
  - `data_config`:
    - ultralytics/datasets/coco128.yaml
    - ultralytics/datasets/coco128-seg.yaml
    - ultralytics/datasets/ImageNet.yaml
    - ultralytics/datasets/coco8-pose.yaml


